### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -10,6 +10,6 @@
     "repo": "googleapis/python-bigquery-logging",
     "distribution_name": "google-cloud-bigquery-logging",
     "api_id": "",
-    "default_version": "",
-    "codeowner_team": ""
+    "default_version": "v1",
+    "codeowner_team": "@googleapis/api-bigquery"
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -6,8 +6,10 @@
     "issue_tracker": "https://github.com/googleapis/python-bigquerylogging/issues",
     "release_level": "beta",
     "language": "python",
-    "library_type" : "OTHER",
+    "library_type": "OTHER",
     "repo": "googleapis/python-bigquery-logging",
     "distribution_name": "google-cloud-bigquery-logging",
-    "api_id": ""
-  }
+    "api_id": "",
+    "default_version": "",
+    "codeowner_team": ""
+}


### PR DESCRIPTION
Set codeowner_team to @googleapis/api-bigquery as codeowner. Set default_version to v1. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114