### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigquerylogging",
     "name_pretty": "BigQuery Logging Protos",
     "product_documentation": "https://cloud.google.com/bigquery/docs/reference/auditlogs",
-    "client_documentation": "https://googleapis.dev/python/bigquerylogging/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/bigquerylogging/latest",
     "issue_tracker": "https://github.com/googleapis/python-bigquerylogging/issues",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.