### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "bigquerylogging",
     "name_pretty": "BigQuery Logging Protos",
     "product_documentation": "https://cloud.google.com/bigquery/docs/reference/auditlogs",
-    "client_documentation": "https://googleapis.dev/python/bigquerylogging/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/bigquerylogging/latest",
     "issue_tracker": "https://github.com/googleapis/python-bigquerylogging/issues",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ This package contains generated Python types for ``google.cloud.bigquery.v1.logg
    :target: https://pypi.org/project/google-cloud-bigquery-logging/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-bigquery-logging.svg
    :target: https://pypi.org/project/google-cloud-bigquery-logging/
-.. _Client Library Documentation: https://googleapis.dev/python/bigquerylogging/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/bigquerylogging/latest
 .. _Product Documentation: https://cloud.google.com/bigquery/docs/reference/auditlogs
 
 


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.